### PR TITLE
Fix eager initialisation of LockBeanPostProcessor's dependencies

### DIFF
--- a/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
+++ b/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.scheduling.TaskScheduler;
@@ -49,12 +50,12 @@ public class DistributedLockConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public LockBeanPostProcessor lockBeanPostProcessor(final KeyGenerator keyGenerator,
-                                                     final ConfigurableBeanFactory configurableBeanFactory,
-                                                     final IntervalConverter intervalConverter,
-                                                     final RetriableLockFactory retriableLockFactory,
-                                                     @Autowired(required = false) final TaskScheduler taskScheduler) {
-    final LockBeanPostProcessor processor = new LockBeanPostProcessor(keyGenerator, configurableBeanFactory::getBean, intervalConverter, retriableLockFactory, taskScheduler);
+  public static LockBeanPostProcessor lockBeanPostProcessor(@Lazy final KeyGenerator keyGenerator,
+                                                            @Lazy final LockTypeResolver lockTypeResolver,
+                                                            @Lazy final IntervalConverter intervalConverter,
+                                                            @Lazy final RetriableLockFactory retriableLockFactory,
+                                                            @Lazy @Autowired(required = false) final TaskScheduler taskScheduler) {
+    final LockBeanPostProcessor processor = new LockBeanPostProcessor(keyGenerator, lockTypeResolver, intervalConverter, retriableLockFactory, taskScheduler);
     processor.setBeforeExistingAdvisors(true);
     return processor;
   }


### PR DESCRIPTION
When declaring a `BeanPostProcessor` it's important to make sure that its
dependencies (and potentially its enclosing class) are not eagerly initialised.
Not doing so can result in the autowired dependencies to not be eligible for
auto-proxying or other kinds of bean post-processing. This is usually indicated
by Spring through an INFO log statement during startup showing each bean that
is affected: 
> Bean someBean is not eligible for getting processed by all BeanPostProcessor
interfaces (for example: not eligible for auto-proxying)

Starting up an application that has enabled distributed lock (through one of
the `@EnableX` annotations) will see the following Spring logs during startup:

```
Bean 'com.github.alturkovic.lock.configuration.DistributedLockConfiguration' of type [com.github.alturkovic.lock.configuration.DistributedLockConfiguration$$EnhancerBySpringCGLIB$$64fee08f] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
Bean 'conversionService' of type [org.springframework.core.convert.support.DefaultConversionService] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
Bean 'spelKeyGenerator' of type [com.github.alturkovic.lock.key.SpelKeyGenerator] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
Bean 'intervalConverter' of type [com.github.alturkovic.lock.interval.BeanFactoryAwareIntervalConverter] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
Bean 'retriableLockFactory' of type [com.github.alturkovic.lock.retry.DefaultRetriableLockFactory] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
Bean 'taskScheduler' of type [org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
```

and potentially more from the app itself if the initialisation of
`LockBeanPostProcessor`'s dependencies causes other indirect dependencies to be
initialised as well.

Declaring the dependencies using `@Lazy` fixes the problem by deferring their
initialisation as late as necessary (being referenced by other beans or
requested from the `BeanFactory`).

See info box "**`BeanPostProcessor` instances and AOP auto-proxying**" in [Spring's
reference doc](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-factory-extension-bpp).