### PR TITLE
Use Spring scheduler if enabled instead of overriding

### DIFF
--- a/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
+++ b/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.TaskManagementConfigUtils;
 
 @Configuration
 public class DistributedLockConfiguration {
@@ -88,7 +89,7 @@ public class DistributedLockConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(name = TaskManagementConfigUtils.SCHEDULED_ANNOTATION_PROCESSOR_BEAN_NAME)
   @ConditionalOnProperty(prefix = "com.github.alturkovic.lock.task-scheduler.default", name = "enabled", havingValue = "true", matchIfMissing = true)
   public TaskScheduler taskScheduler() {
     return new ThreadPoolTaskScheduler();


### PR DESCRIPTION
Spring creates its own TaskScheduler bean if `@EnableScheduler` is used. This library overrides Spring's TaskSchduler because it uses the same name/type and therefore Spring's bean is not used. This is the easiest way to deal with it, the only downside is that if people use `@Scheduled` without `@EnableScheduler` it will still work with this libary's TaskScheduler. The other is that you might want to use a dedicated TaskScheduler for refreshing. For the latter you could always override the LockBeanPostProcessor. I guess that would be applicable for such an advanced use case.

Alternatives:
- Use dedicated task scheduler with a different bean name, so it is easy extendable (downside, you cannot use Spring's one easily)