### PR TITLE
fix: the default table name is 'lock' which overlaps with keyword in …

### DIFF
--- a/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/service/SimpleJdbcLockSingleKeyService.java
+++ b/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/service/SimpleJdbcLockSingleKeyService.java
@@ -38,10 +38,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 public class SimpleJdbcLockSingleKeyService implements JdbcLockSingleKeyService {
 
-  public static final String ACQUIRE_FORMATTED_QUERY = "INSERT INTO %s (lock_key, token, expireAt) VALUES (?, ?, ?);";
-  public static final String RELEASE_FORMATTED_QUERY = "DELETE FROM %s WHERE lock_key = ? AND token = ?;";
-  public static final String DELETE_EXPIRED_FORMATTED_QUERY = "DELETE FROM %s WHERE expireAt < ?;";
-  public static final String REFRESH_FORMATTED_QUERY = "UPDATE %s SET expireAt = ? WHERE lock_key = ? AND token = ?;";
+  public static final String ACQUIRE_FORMATTED_QUERY = "INSERT INTO `%s` (lock_key, token, expireAt) VALUES (?, ?, ?);";
+  public static final String RELEASE_FORMATTED_QUERY = "DELETE FROM `%s` WHERE lock_key = ? AND token = ?;";
+  public static final String DELETE_EXPIRED_FORMATTED_QUERY = "DELETE FROM `%s` WHERE expireAt < ?;";
+  public static final String REFRESH_FORMATTED_QUERY = "UPDATE `%s` SET expireAt = ? WHERE lock_key = ? AND token = ?;";
 
   private final JdbcTemplate jdbcTemplate;
 


### PR DESCRIPTION
fixing issue: https://github.com/alturkovic/distributed-lock/issues/24


I have created SQL table using the following script from the documentation:
```
CREATE TABLE lock (
    id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
    lock_key varchar(255) UNIQUE,
    token varchar(255),
    expireAt TIMESTAMP,
    PRIMARY KEY(`id`)
);
```

After that I'm using the following code:
```
@JdbcLocked(prefix = "accountId", expression = "#accountId", storeId = "`lock`")
```


This result in the following exception:
```
java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'lock WHERE expireAt < '2022-08-21 19:20:56.016'' at line 1
	...
	com.github.alturkovic.lock.jdbc.service.SimpleJdbcLockSingleKeyService.acquire(SimpleJdbcLockSingleKeyService.java:51)
	at com.github.alturkovic.lock.jdbc.service.SimpleJdbcLockSingleKeyService$$FastClassBySpringCGLIB$$7d90f809.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	...

```

I manage to fix this in my code by overriding storeId:
```
@JdbcLocked(prefix = "accountId", expression = "#accountId", storeId = "`lock`")
```


In MySql  'lock' is keyword so if you are using this for table name you need to escape it. So every SQL query in `SimpleJdbcLockSingleKeyService` need to be scaped with `

like this:
```
  public static final String ACQUIRE_FORMATTED_QUERY = "INSERT INTO `%s` (lock_key, token, expireAt) VALUES (?, ?, ?);";
  public static final String RELEASE_FORMATTED_QUERY = "DELETE FROM `%s` WHERE lock_key = ? AND token = ?;";
  public static final String DELETE_EXPIRED_FORMATTED_QUERY = "DELETE FROM `%s` WHERE expireAt < ?;";
  public static final String REFRESH_FORMATTED_QUERY = "UPDATE `%s` SET expireAt = ? WHERE lock_key = ? AND token = ?;";
```


I will create a pull request for this