### PR TITLE
Use dedicated task scheduler for DistributedLock, avoid trying to override custom default scheduler

### DIFF
--- a/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
+++ b/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
@@ -55,8 +55,8 @@ public class DistributedLockConfiguration {
                                                             @Lazy final LockTypeResolver lockTypeResolver,
                                                             @Lazy final IntervalConverter intervalConverter,
                                                             @Lazy final RetriableLockFactory retriableLockFactory,
-                                                            @Lazy @Autowired(required = false) final TaskScheduler taskScheduler) {
-    final LockBeanPostProcessor processor = new LockBeanPostProcessor(keyGenerator, lockTypeResolver, intervalConverter, retriableLockFactory, taskScheduler);
+                                                            @Lazy @Autowired(required = false) final TaskScheduler distributedLockTaskScheduler) {
+    final LockBeanPostProcessor processor = new LockBeanPostProcessor(keyGenerator, lockTypeResolver, intervalConverter, retriableLockFactory, distributedLockTaskScheduler);
     processor.setBeforeExistingAdvisors(true);
     return processor;
   }

--- a/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
+++ b/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
@@ -91,7 +91,7 @@ public class DistributedLockConfiguration {
   @Bean
   @ConditionalOnMissingBean(name = TaskManagementConfigUtils.SCHEDULED_ANNOTATION_PROCESSOR_BEAN_NAME)
   @ConditionalOnProperty(prefix = "com.github.alturkovic.lock.task-scheduler.default", name = "enabled", havingValue = "true", matchIfMissing = true)
-  public TaskScheduler taskScheduler() {
+  public TaskScheduler distributedLockTaskScheduler() {
     return new ThreadPoolTaskScheduler();
   }
 }


### PR DESCRIPTION
The current `taskScheduler` in the `DistributedLockConfiguration` understands not to override the default Spring scheduler, but tries to override if the app has defined a custom default scheduler.

For example, in your `SpringBootApplication.class` you may have the following scheduler, which is used instead of the default one for all the methods annotated with `@Scheduled`:

```java
    /**
     * This is a configuration bean which will create/replace the @Scheduled task executor created by
     * the Spring Framework with an identical one that also supports graceful shutdowns
     */
    @Bean
    public ThreadPoolTaskScheduler taskScheduler() {
        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
        taskScheduler.setPoolSize(1);
        taskScheduler.setThreadNamePrefix("Scheduler-");
        taskScheduler.setWaitForTasksToCompleteOnShutdown(true); // Wait for tasks to complete before shutting down
        taskScheduler.setAwaitTerminationSeconds(30); // Set the maximum wait time for tasks to complete
        return taskScheduler;
    }
```

If you try to launch this spring boot app with the default DistributedLock configuration as per the README.md, you'll get an error that `A bean with that name has already been defined in class path resource [com/github/alturkovic/lock/configuration/DistributedLockConfiguration.class] and overriding is disabled.`

There is no way to rename the DistributedLock scheduler bean from overriding.

Despite what the `@ConditionalOnProperty(prefix = "com.github.alturkovic.lock.task-scheduler.default", name = "enabled", havingValue = "true", matchIfMissing = true)` seems to imply, adding `com.github.alturkovic.lock.task-scheduler.default=false` to one's `application.properties` does not resolve the issue. This property seems to be ignored by Spring completely.

It's also bad practice to use the main scheduler for the lock because the main scheduler thread might be very busy with other tasks, and so locks won't get cleared as efficiently as they need to be.