### PR TITLE
Added throwing option to Locked annotations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,6 +24,9 @@ They wrap the `@Locked` annotation and define the type used.
 Each lock needs to define a https://docs.spring.io/spring/docs/current/spring-framework-reference/html/expressions.html[SpEL] expression used to acquire the lock.
 To learn more about Spring aliases visit https://github.com/spring-projects/spring-framework/wiki/Spring-Annotation-Programming-Model[this] link.
 
+By default, upon failure to acquire the lock `@Locked` will throw `DistributedLockException`. If you need to only log this failure without raising the exception add `throwing = false` to your
+`@Locked` annotation. This is useful if you need to lock an action across multiple application instances, for example cron.
+
 === Lock refresh
 
 Locks can be refreshed automatically on a regular interval. This allows methods that occasionally need to run longer than their expiration.
@@ -319,6 +322,10 @@ You can also create an alias for your lock so you don't have to specify `@Locked
 == Changelog
 
 Started tracking the changes since 1.2.0 so no changelogs available for earlier versions.
+
+==== 2.1.0
+
+- FEATURE: Added option `throwing` to `@Locked` annotations
 
 ==== 2.0.0
 

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,8 @@ Each lock needs to define a https://docs.spring.io/spring/docs/current/spring-fr
 To learn more about Spring aliases visit https://github.com/spring-projects/spring-framework/wiki/Spring-Annotation-Programming-Model[this] link.
 
 By default, upon failure to acquire the lock `@Locked` will throw `DistributedLockException`. If you need to only log this failure without raising the exception add `throwing = false` to your
-`@Locked` annotation. This is useful if you need to lock an action across multiple application instances, for example cron.
+`@Locked` annotation. Using this option on non-void methods will make the method return null - using primitives as return type with this option is not advised. This is useful if you need to lock
+an action across multiple application instances, for example cron.
 
 === Lock refresh
 

--- a/distributed-lock-api/src/main/java/com/github/alturkovic/lock/Locked.java
+++ b/distributed-lock-api/src/main/java/com/github/alturkovic/lock/Locked.java
@@ -94,6 +94,8 @@ public @interface Locked {
   /**
    * Flag to indicate whether an exception should be thrown or logged only.
    * By default, an exception will be thrown upon lock failure.
+   *
+   * If false, non-void method will return {@code null} upon lock failure.
    */
   boolean throwing() default true;
 }

--- a/distributed-lock-api/src/main/java/com/github/alturkovic/lock/Locked.java
+++ b/distributed-lock-api/src/main/java/com/github/alturkovic/lock/Locked.java
@@ -90,4 +90,10 @@ public @interface Locked {
    * Lock type, see implementations of {@link Lock}.
    */
   Class<? extends Lock> type() default Lock.class;
+
+  /**
+   * Flag to indicate whether an exception should be thrown or logged only.
+   * By default, an exception will be thrown upon lock failure.
+   */
+  boolean throwing() default true;
 }

--- a/distributed-lock-core/src/main/java/com/github/alturkovic/lock/advice/LockMethodInterceptor.java
+++ b/distributed-lock-core/src/main/java/com/github/alturkovic/lock/advice/LockMethodInterceptor.java
@@ -59,6 +59,12 @@ public class LockMethodInterceptor implements MethodInterceptor {
     final LockContext context = new LockContext(invocation);
     try {
       return executeLockedMethod(invocation, context);
+    } catch (DistributedLockException e) {
+      if (context.getLocked() != null && !context.getLocked().throwing()) {
+        log.warn("Cannot obtain lock for keys {} in store {}", context.getKeys(), context.getLocked().storeId(), e);
+        return null;
+      }
+      throw e;
     } finally {
       cleanAfterExecution(context);
     }

--- a/distributed-lock-core/src/test/java/com/github/alturkovic/lock/advice/LockBeanPostProcessorTest.java
+++ b/distributed-lock-core/src/test/java/com/github/alturkovic/lock/advice/LockBeanPostProcessorTest.java
@@ -48,6 +48,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
 public class LockBeanPostProcessorTest {
@@ -151,6 +152,11 @@ public class LockBeanPostProcessorTest {
       .isInstanceOf(DistributedLockException.class);
   }
 
+  @Test
+  public void shouldNotThrowWhenNoTokenIsAcquiredAfterRetries() {
+    assertDoesNotThrow(() -> lockedInterface.notThrown("!noToken"));
+  }
+
   private interface LockedInterface {
 
     @Locked(prefix = "lock:", expression = "#s", type = SimpleLock.class)
@@ -182,6 +188,9 @@ public class LockBeanPostProcessorTest {
 
     @SimpleLocked(expression = "#token")
     void noToken(String token);
+
+    @SimpleLocked(throwing = false)
+    void notThrown(String token);
   }
 
   private class LockedInterfaceImpl implements LockedInterface {
@@ -234,6 +243,10 @@ public class LockBeanPostProcessorTest {
 
     @Override
     public void noToken(String token) {
+    }
+
+    @Override
+    public void notThrown(String token) {
     }
 
     public int getStaticValue() {

--- a/distributed-lock-core/src/test/java/com/github/alturkovic/lock/advice/support/SimpleLocked.java
+++ b/distributed-lock-core/src/test/java/com/github/alturkovic/lock/advice/support/SimpleLocked.java
@@ -61,4 +61,7 @@ public @interface SimpleLocked {
 
   @AliasFor(annotation = Locked.class)
   Interval refresh() default @Interval(value = "0");
+
+  @AliasFor(annotation = Locked.class)
+  boolean throwing() default true;
 }

--- a/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/alias/JdbcLocked.java
+++ b/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/alias/JdbcLocked.java
@@ -62,4 +62,7 @@ public @interface JdbcLocked {
 
   @AliasFor(annotation = Locked.class)
   Interval refresh() default @Interval(value = "0");
+
+  @AliasFor(annotation = Locked.class)
+  boolean throwing() default true;
 }

--- a/distributed-lock-mongo/src/main/java/com/github/alturkovic/lock/mongo/alias/MongoLocked.java
+++ b/distributed-lock-mongo/src/main/java/com/github/alturkovic/lock/mongo/alias/MongoLocked.java
@@ -62,4 +62,7 @@ public @interface MongoLocked {
 
   @AliasFor(annotation = Locked.class)
   Interval refresh() default @Interval(value = "0");
+
+  @AliasFor(annotation = Locked.class)
+  boolean throwing() default true;
 }

--- a/distributed-lock-redis/src/main/java/com/github/alturkovic/lock/redis/alias/RedisLocked.java
+++ b/distributed-lock-redis/src/main/java/com/github/alturkovic/lock/redis/alias/RedisLocked.java
@@ -62,4 +62,7 @@ public @interface RedisLocked {
 
   @AliasFor(annotation = Locked.class)
   Interval refresh() default @Interval(value = "0");
+
+  @AliasFor(annotation = Locked.class)
+  boolean throwing() default true;
 }

--- a/distributed-lock-redis/src/main/java/com/github/alturkovic/lock/redis/alias/RedisMultiLocked.java
+++ b/distributed-lock-redis/src/main/java/com/github/alturkovic/lock/redis/alias/RedisMultiLocked.java
@@ -62,4 +62,7 @@ public @interface RedisMultiLocked {
 
   @AliasFor(annotation = Locked.class)
   Interval refresh() default @Interval(value = "0");
+
+  @AliasFor(annotation = Locked.class)
+  boolean throwing() default true;
 }


### PR DESCRIPTION
Closes #41

Changes:

- added throwing option to all `Locked` annotations 
- documented how to use `throwing` in README
- started new release changelog in README